### PR TITLE
译名标准化

### DIFF
--- a/src/modules/map_art/map_art_data.ts
+++ b/src/modules/map_art/map_art_data.ts
@@ -37,7 +37,7 @@ export interface SubData {
 
 const categoryData = {
     "wool": "羊毛",
-    "clay": "粘土",
+    "clay": "陶瓦与黏土",
     "concrete": "混凝土",
     "stone": "石材",
     "crafted": "工艺制品",
@@ -46,7 +46,7 @@ const categoryData = {
     "ore": "矿石",
     "the_end": "末地建材",
     "natural": "主世界",
-    "nether": "地狱建材",
+    "nether": "下界建材",
     "ocean": "海洋建材"
 }
 export interface RawData {


### PR DESCRIPTION
方块选择器中的方块分组名称：更改为更加标准的名称，符合实际内容