### PR TITLE
修正/润色英文和中文文本

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,9 +27,9 @@ export default {
     upload: {
       title: 'Schematic Processing',
       dragDrop: 'Drag and drop files or click to upload',
-      supportedFormats: 'Supported formats: nbt, litematic, schem, json, mcstruct (max 50MB) Multiple files allowed',
+      supportedFormats: 'Supported formats: nbt, litematic, schem, json, mcstruct (max 50MB). Multiple files allowed',
       selectFile: 'Select File',
-      uploadSuccess: 'Successfully uploaded {count} files',
+      uploadSuccess: 'Successfully uploaded {count} file(s)',
       uploadError: 'Error occurred: {error}'
     },
     supportedTypes: {
@@ -79,7 +79,7 @@ export default {
     },
     resources: {
       title: 'Resource Files',
-      clear: 'Clear Resource Files (This will delete all resource files and your stored blueprints)',
+      clear: 'Clear Resource Files (This will delete all resource files and your stored schematics)',
       clearConfirm: 'Confirm Clear',
       clearWarning: 'Clearing will cause all data to be lost, please backup first',
       openFolder: 'Open Resource Folder',
@@ -91,7 +91,7 @@ export default {
     }
   },
   messages: {
-    clearSuccess: 'Resource files cleared, will restart in 5s',
+    clearSuccess: 'Resource files cleared, will restart in 5 seconds',
     error: 'An error occurred: {error}',
     fetchError: 'Failed to fetch schematic: {error}'
   },
@@ -159,11 +159,11 @@ export default {
         }
       },
       meta: {
-        extension: 'Extension Type',
+        extension: 'Extension',
         originalSize: 'Original Size',
         version: 'Version',
         subVersion: 'Sub Version',
-        exists: 'Exists',
+        exists: 'Already Exists',
         gzipCompression: 'Gzip Compression',
         hasSubVersions: 'Has Sub Versions'
       }
@@ -223,7 +223,7 @@ export default {
         orange: 'Vibrant Orange',
         yellow: 'Pineapple Yellow',
         brown: 'Oak Brown',
-        greyDark: 'Dark Mode'
+        greyDark: 'Dark'
       }
     },
     background: {
@@ -234,21 +234,21 @@ export default {
       resolution: 'Resolution',
       layoutMode: 'Layout method',
       layoutModes: {
-        stretch: 'Stretch Fill',
-        repeat: 'Tile Repeat',
-        contain: 'Fit Screen',
-        cover: 'Full Cover'
+        stretch: 'Stretch',
+        repeat: 'Tile',
+        contain: 'Fit',
+        cover: 'Fill'
       },
       actions: {
-        clear: 'Clear Background',
-        refresh: 'Refresh Background',
-        select: 'Select Background File'
+        clear: 'Clear Background Image',
+        refresh: 'Refresh Background Image',
+        select: 'Select Background Image'
       }
     }
   },
   about: {
     title: 'About',
-    version: 'Version: v{version}',
+    version: 'Version: {version}',
     actions: {
       checkUpdate: 'Check for Updates',
       changelog: 'Changelog',
@@ -258,8 +258,8 @@ export default {
       faq: 'FAQ→'
     },
     description: {
-      title: 'Software Description',
-      content: 'The software uses Tauri backend based on Rust and Vue frontend.\nModular design ensures software performance, Rust\'s safety design provides better performance and memory safety.'
+      title: 'App Description',
+      content: 'The app uses Tauri backend based on Rust and Vue frontend.\nModular design ensures app performance, Rust\'s safety design provides better performance and memory safety.'
     },
     schematicSite: {
       title: 'Schematic Site',
@@ -268,7 +268,7 @@ export default {
     },
     tauri: {
       title: 'Tauri 2.0',
-      tooltip: 'Software developed using Tauri 2.0',
+      tooltip: 'The app is developed using Tauri 2.0',
       currentVersion: 'Current Version: {version}'
     },
     license: {

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -23,14 +23,14 @@ export default {
     actions: {
       checkUpdate: '检测更新',
       changelog: '更新日志',
-      github: 'Github',
+      github: 'GitHub',
       website: '官方网站',
       sponsor: '赞助项目',
-      faq: 'FAQ→'
+      faq: '常见问题→'
     },
     description: {
       title: '软件说明',
-      content: '软件使用tauri 后端基于rust，前端使用vue.\n分离化设计让软件性能得到保障，rust安全设计，性能更好，内存安全高效。'
+      content: '软件使用 Tauri，后端基于 Rust，前端使用 Vue。\n分离化设计让软件性能得到保障，Rust 安全设计，性能更好，内存安全高效。'
     },
     schematicSite: {
       title: '蓝图站',
@@ -39,7 +39,7 @@ export default {
     },
     tauri: {
       title: 'Tauri 2.0',
-      tooltip: '软件基于tauri 2.0开发制作',
+      tooltip: '软件基于 Tauri 2.0 开发制作',
       currentVersion: '当前版本: {version}'
     },
     license: {
@@ -50,7 +50,7 @@ export default {
     },
     developers: {
       title: '核心开发人员',
-      tooltip: '参与开发及代表明确遵守AGPL V3协议,改版 转发请注明所有开发人员和协议',
+      tooltip: '参与开发及代表明确遵守 AGPL V3 协议，改版、转发请注明所有开发人员和协议',
       author: '作者'
     }
   },
@@ -64,10 +64,10 @@ export default {
     upload: {
       title: '蓝图处理',
       dragDrop: '拖放文件或点击上传',
-      supportedFormats: '支持格式：nbt、litematic、schem、 json、 mcstruct（最大50MB）允许多选',
+      supportedFormats: '支持格式：nbt、litematic、schem、json、mcstruct（最大50MB）允许多选',
       selectFile: '选择文件',
       uploadSuccess: '成功上传 {count} 个文件',
-      uploadError: '发生错误:{error}'
+      uploadError: '发生错误：{error}'
     },
     supportedTypes: {
       title: '支持蓝图类型',
@@ -80,11 +80,11 @@ export default {
         desc: '科技包最常见的辅组建筑工具'
       },
       litematica: {
-        title: '建筑投影',
+        title: '建筑投影（Litematica）',
         desc: '生电玩家活下去的必备工具'
       },
       worldEdit: {
-        title: '创世神',
+        title: '创世神（WorldEdit）',
         desc: '老牌建筑工具，延用至今，新版axiom也采用了这种蓝图格式'
       },
       bedrock: {
@@ -112,11 +112,11 @@ export default {
     },
     theme: {
       title: '跟随主题',
-      autoTheme: '启用系统跟随(页面主题将跟随windows主题变化)'
+      autoTheme: '启用系统跟随（页面主题将跟随Windows主题变化）'
     },
     resources: {
       title: '资源文件',
-      clear: '清除资源文件(将删除所有资源文件，你存储的蓝图)',
+      clear: '清除资源文件（将删除所有资源文件，你存储的蓝图）',
       clearConfirm: '确认清除',
       clearWarning: '清除将导致数据全部丢失，建议先进行备份',
       openFolder: '打开资源文件夹',
@@ -128,8 +128,8 @@ export default {
     }
   },
   messages: {
-    clearSuccess: '已清除资源文件，将在5s后重启',
-    error: '发生了一个错误: {error}',
+    clearSuccess: '已清除资源文件，将在5秒后重启',
+    error: '发生错误: {error}',
     fetchError: '获取原理图失败: {error}'
   },
   tools: {
@@ -166,12 +166,12 @@ export default {
           ext: 'nbt'
         },
         litematica: {
-          title: '投影蓝图',
-          desc: '适配 我的世界建筑投影蓝图格式',
+          title: '投影蓝图（Litematica）',
+          desc: '适配 Minecraft 建筑投影蓝图格式',
           ext: 'litematic'
         },
         worldEdit: {
-          title: '创世神',
+          title: '创世神（WorldEdit）',
           desc: '适配与新版1.16 + 创世神模组和最新版 axios',
           ext: 'schem',
           versions: {
@@ -196,7 +196,7 @@ export default {
         }
       },
       meta: {
-        extension: '后缀类型',
+        extension: '扩展名',
         originalSize: '原始大小',
         version: '版本',
         subVersion: '子版本',
@@ -223,12 +223,12 @@ export default {
     tip: '有问题先不要盲目，乱求医。先尝试自己解决一下！',
     channels: {
       github: {
-        title: 'GitHub issue',
-        desc: '通过Github issue向我们反馈bug和问题'
+        title: 'GitHub Issue',
+        desc: '通过GitHub Issue向我们反馈bug和问题'
       },
       qqGroup: {
-        title: 'QQ群聊',
-        desc: '加入官方Q群反馈问题bug'
+        title: 'QQ群',
+        desc: '加入官方QQ群反馈问题bug'
       },
       qqChannel: {
         title: 'QQ频道',
@@ -271,10 +271,10 @@ export default {
       resolution: '分辨率',
       layoutMode: '布局方式',
       layoutModes: {
-        stretch: '拉伸填充',
-        repeat: '平铺重复',
-        contain: '适应屏幕',
-        cover: '完整覆盖'
+        stretch: '拉伸',
+        repeat: '平铺',
+        contain: '适应',
+        cover: '填充'
       },
       actions: {
         clear: '清除背景',


### PR DESCRIPTION
对于 `en.ts`:
- blueprint -> schematic
- software -> app (application)
- 其他小更改
对于 `zh.ts`:
- 标点统一为全角
- 英文词统一大小写，如 github -> GitHub
- 为Mod名称补上原名，如 创世神（WorldEdit）
- `layoutModes` 的名称使用更规范的称呼（见下图）
![image](https://github.com/user-attachments/assets/f4f86b39-024a-4a24-b84c-18b2359e44bf)
- 其他小更改
`ja.ts` 由于不会霓虹话，没法校对